### PR TITLE
Kernel-related changes made while fixing brightness config of lemonades

### DIFF
--- a/README
+++ b/README
@@ -1,6 +1,21 @@
 Linux kernel
 ============
 
+> ⚠️ **WARNING**
+> 
+> For OnePlus 9R (lemonades), the kernel configuration has been modified
+> to expose the HBM (High Brightness Mode) brightness range of the
+> display. This is intended for use with a device tree that takes this
+> into account either by disabling the entire HBM range or properly
+> configuring HBM transition point. Failing to do this may result in
+> staying in the HBM range for too long and damaging the display hardware.
+>
+> Brightness of the recovery might also need to be tuned to avoid making
+> the screen too bright.
+>
+> Beware that up to 2026-05-27, most custom ROMs (including official
+> LineageOS) has not yet implemented this for OnePlus 9R.
+
 There are several guides for kernel developers and users. These guides can
 be rendered in a number of formats, like HTML and PDF. Please read
 Documentation/admin-guide/README.rst first.

--- a/arch/arm64/boot/dts/vendor/oplus/lemonades/dsi-panel-oplus20828-samsung-amb655x-1080-2400-120fps.dtsi
+++ b/arch/arm64/boot/dts/vendor/oplus/lemonades/dsi-panel-oplus20828-samsung-amb655x-1080-2400-120fps.dtsi
@@ -669,9 +669,9 @@
 	qcom,mdss-dsi-bl-pmic-control-type = "bl_ctrl_dcs";
 	qcom,mdss-dsi-bl-min-level = <1>;
 	qcom,mdss-dsi-bl-normal-max-level = <2047>;
-	qcom,mdss-dsi-bl-max-level = <2047>;
+	qcom,mdss-dsi-bl-max-level = <4095>;
 	qcom,mdss-brightness-normal-max-level = <2047>;
-	qcom,mdss-brightness-max-level = <2047>;
+	qcom,mdss-brightness-max-level = <4095>;
 	qcom,mdss-brightness-default-level = <360>;
 	qcom,platform-te-gpio = <&tlmm 66 0>;
 	qcom,platform-reset-gpio =  <&tlmm 75 0>;

--- a/arch/arm64/boot/dts/vendor/oplus/lemonades/kona-sensor.dtsi
+++ b/arch/arm64/boot/dts/vendor/oplus/lemonades/kona-sensor.dtsi
@@ -2,7 +2,7 @@
 	oplus_sensor {
 		compatible = "oplus,sensor-devinfo";
 
-		als-row-coe = <116>;
+		als-row-coe = <466>;
 
 		/* enum {LSM6DSM = 0x01, BMI160 = 0x02, LSM6DS3 = 0x04, BMI260 = 0x8}; */
 		gsensor@0 {
@@ -48,10 +48,10 @@
 			sensor-type = <3>; // OPLUS_LIGHT
 			bus-number = <5>;
 			irq-number = <122>;
-			als-type = <3>; // 1 - normal; 2 - under screen; 3 - normal needed compensation
+			als-type = <2>; // 1 - normal; 2 - under screen; 3 - normal needed compensation
 			is-unit-device = <1>; // 1 - alsps unit device; 0 - separate device
 			is-als-dri = <0>; // 0 - polling; 1 - irq
-			als-factor = <116>;
+			als-factor = <466>;
 			is_als_initialed = <0>;
 			als_buffer_length = <10>;
 		};


### PR DESCRIPTION
1. The maximum display brightness exposed by the kernel is changed from 2047 (sustainable maximum) to 4095 (HBM maximum), so that the system can make use of HBM brightness. For example, the system will be able to temporarily go beyond the sustainable maximum under intense ambient light, enhancing readability of the screen.
2. The ambient light sensor config is changed to match kebab (OnePlus 8T), which correctly reflects that the sensor is under display.

This pull request is intended to be used with neokoni/android_device_oneplus_lemonades#1 and neokoni/android_device_oneplus_sm8250-common#1.